### PR TITLE
Optimize prefix sum computation in Lucene99HnswVectorsReader

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene99/Lucene99HnswVectorsReader.java
@@ -552,9 +552,11 @@ public final class Lucene99HnswVectorsReader extends KnnVectorsReader
       arcCount = dataIn.readVInt();
       assert arcCount <= currentNeighborsBuffer.length : "too many neighbors: " + arcCount;
       if (arcCount > 0) {
-        currentNeighborsBuffer[0] = dataIn.readVInt();
-        for (int i = 1; i < arcCount; i++) {
-          currentNeighborsBuffer[i] = currentNeighborsBuffer[i - 1] + dataIn.readVInt();
+        // Faster prefix sum computation (see #14979)
+        int sum = 0;
+        for (int i = 0; i < arcCount; i++) {
+          sum += dataIn.readVInt();
+          currentNeighborsBuffer[i] = sum;
         }
       }
       arc = -1;


### PR DESCRIPTION
Replaced the two-step prefix sum loop in `Lucene99HnswVectorsReader` with a single-loop variant that avoids redundant memory access and improves performance.

Fixes:  #15024

Previous approach:
- Read first value separately.
- Then used previous buffer element + readVInt().

New approach:
- Accumulates sum in a single pass and assigns directly.

This change follows the suggestion from issue #14979 and has the same functional behavior with slightly better efficiency.

